### PR TITLE
Compile AngularJS Templates

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
       img       : 'img/**/*',
       js        : '**/*.js',
       less      : 'less/**/*.less',
-      views     : 'views/**/*'
+      html      : '**/*.html'
     },
 
     // Common
@@ -63,7 +63,7 @@ module.exports = function(grunt) {
       app:      {
         src     : ['<%= dirs.lib %>/github-fork-ribbon-css/gh-fork-ribbon.css'
                   ,'<%= dirs.client %>/less/app.less'],
-        dest    : '<%= dirs.build %>/css/<%= pkg.name %>.css'
+        dest    : '<%= dirs.build %>/css/app.css'
       }
     },
 
@@ -82,22 +82,40 @@ module.exports = function(grunt) {
         files   : { '<%= dirs.build %>img/': '<%= dirs.lib %>/bootstrap/<%= files.img %>' }
       }
     },
+    ngtemplates:{
+      app:      {
+        options : {
+          base  : '<%= dirs.client %>'
+        },
+        src     : ['<%= dirs.client + files.html %>'],
+        dest    : '<%= dirs.build %>/js/templates.js'
+      }
+    },
     concat:     {
+      angular:  {
+        src     : ['<%= dirs.lib %>/angular-1.0.3/angular.js'
+                  ,'<%= dirs.lib %>/angular-1.0.3/angular-resource.js'],
+        dest    : '<%= dirs.build %>/js/lib/angular.js'
+      },
+      app:      {
+        src     : ['<banner:meta.banner>'
+                  ,'<%= dirs.client + files.js %>'
+                  ,'<%= ngtemplates.app.dest %>'],
+        dest    : '<%= dirs.build %>/js/app.js'
+      },
       all:      {
         src     : ['<banner:meta.banner>'
-                  ,'<%= dirs.lib %>/angular-1.0.3/angular.js'
-                  ,'<%= dirs.lib %>/angular-1.0.3/angular-resource.js'
-                  ,'<%= dirs.client %>/js/app.js'
-                  ,'<%= dirs.client + files.js %>'],
-        dest    : '<%= dirs.build %>/js/<%= pkg.name %>.js'
+                  ,'<%= concat.angular.dest %>'
+                  ,'<%= concat.app.dest %>'],
+        dest    : '<%= dirs.build %>/js/all.js'
       }
     },
 
     // Minification
     cssmin:     {
-      all:      {
+      app:      {
         src     : ['<banner:meta.banner>', '<%= less.app.dest %>'],
-        dest    : '<%= dirs.build %>/css/<%= pkg.name %>.min.css'
+        dest    : '<%= less.app.dest.replace(".css", ".min.css") %>'
       }
     },
     smushit:    {
@@ -106,9 +124,17 @@ module.exports = function(grunt) {
       }
     },
     min:     {
+      angular:  {
+        src     : '<%= concat.angular.dest %>',
+        dest    : '<%= concat.angular.dest.replace(".js", ".min.js") %>'
+      },
       app:      {
+        src     : ['<banner:meta.banner>', '<%= concat.app.dest %>'],
+        dest    : '<%= concat.app.dest.replace(".js", ".min.js") %>'
+      },
+      all:      {
         src     : ['<banner:meta.banner>', '<%= concat.all.dest %>'],
-        dest    : '<%= dirs.build %>/js/<%= pkg.name %>.min.js'
+        dest    : '<%= concat.all.dest.replace(".js", ".min.js") %>'
       }
     },
 
@@ -136,6 +162,7 @@ module.exports = function(grunt) {
    * Dependencies
    */
 
+  grunt.loadNpmTasks('grunt-angular-templates');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-less');
@@ -148,8 +175,9 @@ module.exports = function(grunt) {
    * Tasks
    */
 
-  grunt.registerTask('default',         ['lint', 'less', 'concat', 'copy']);
-  grunt.registerTask('build',           ['clean','default', 'minify']);
+  grunt.registerTask('default',         ['lint', 'compile', 'concat', 'copy']);
+  grunt.registerTask('compile',         ['less', 'ngtemplates']);
+  grunt.registerTask('build',           ['clean', 'default', 'minify']);
   grunt.registerTask('minify',          ['cssmin', 'min', 'smushit']);
   grunt.registerTask('server',          ['default', 'express-server', 'reload', 'open', 'watch']);
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bower": "0.6.8",
     "express": "3.0.5",
     "grunt": "0.3.17",
-    "grunt-angular-templates": "~0.1.0",
+    "grunt-angular-templates": "~0.1.2",
     "grunt-css": "0.3.2",
     "grunt-contrib-copy": "0.3.2",
     "grunt-contrib-less": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bower": "0.6.8",
     "express": "3.0.5",
     "grunt": "0.3.17",
+    "grunt-angular-templates": "~0.1.0",
     "grunt-css": "0.3.2",
     "grunt-contrib-copy": "0.3.2",
     "grunt-contrib-less": "0.3.2",

--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -1,5 +1,6 @@
 angular
   .module('app', [
+    'app.templates',
     'ngResource'
   ])
   .config(['$routeProvider', function($router) {

--- a/src/client/views/about.html
+++ b/src/client/views/about.html
@@ -1,0 +1,10 @@
+<h3>About</h3>
+
+<p>
+  Genesis Skeleton aims to be the best starting point for your next
+  <a href="http://expressjs.com/">Express</a> + <a href="http://angularjs.org/">AngularJS</a>
+  app.
+
+  Assets are automatically concatenated &amp; minified with <a href="http://gruntjs.com/">Grunt</a>,
+  ready to change &amp; deploy.
+</p>

--- a/src/client/views/get-started.html
+++ b/src/client/views/get-started.html
@@ -1,0 +1,21 @@
+<h3>Get Started in <em>5 Easy Steps</em></h3>
+
+<ol>
+  <li>
+    <a href="https://github.com/ericclemmons/genesis-skeleton/archive/master.zip" class="btn btn-small"><strong>Download</strong></a>
+    or
+    <code>git clone git://github.com/ericclemmons/genesis-skeleton.git</code>
+  </li>
+  <li>
+    <strong>Install</strong> dependencies: <code>npm install</code>
+  </li>
+  <li>
+    <strong>Preview</strong> your changes <em>live</em>: <code>grunt server</code>
+  </li>
+  <li>
+    <strong>Create</strong> a Heroku server: <code>heroku create</code>
+  </li>
+  <li>
+    <strong>Launch</strong> your app! <code>git push heroku master</code>
+  </li>
+</ol>

--- a/src/client/views/home.html
+++ b/src/client/views/home.html
@@ -8,14 +8,12 @@
 
     <div class="masthead">
       <ul class="nav nav-pills pull-right">
-        <li class="active"><a>Home</a></li>
-        <li><a>Get Started</a></li>
-        <li><a>Technology</a></li>
+        <li class="active"><a href="/">Home</a></li>
+        <li><a href="{{ $lolget-started">Get Started</a></li>
+        <li><a href="technology">Technology</a></li>
       </ul>
 
-      <h3 class="muted">
-        Genesis Skeleton
-      </h3>
+      <h3 class="muted">Genesis Skeleton</h3>
     </div>
 
     <div class="jumbotron">
@@ -25,115 +23,15 @@
 </header>
 
 <section id="about">
-  <div class="container-narrow">
-    <h3>About</h3>
-
-    <p>
-      Genesis Skeleton aims to be the best starting point for your next
-      <a href="http://expressjs.com/">Express</a> + <a href="http://angularjs.org/">AngularJS</a>
-      app.
-
-      Assets are automatically concatenated &amp; minified with <a href="http://gruntjs.com/">Grunt</a>,
-      ready to change &amp; deploy.
-    </p>
-  </div>
+  <div class="container-narrow" ng-include="'views/about.html'"></div>
 </section>
 
 <section id="get-started">
-  <div class="container-narrow">
-    <h3>Get Started in <em>5 Easy Steps</em></h3>
-
-    <ol>
-      <li>
-        <a href="https://github.com/ericclemmons/genesis-skeleton/archive/master.zip" class="btn btn-small"><strong>Download</strong></a>
-        or
-        <code>git clone git://github.com/ericclemmons/genesis-skeleton.git</code>
-      </li>
-      <li>
-        <strong>Install</strong> dependencies: <code>npm install</code>
-      </li>
-      <li>
-        <strong>Preview</strong> your changes <em>live</em>: <code>grunt server</code>
-      </li>
-      <li>
-        <strong>Create</strong> a Heroku server: <code>heroku create</code>
-      </li>
-      <li>
-        <strong>Launch</strong> your app! <code>git push heroku master</code>
-      </li>
-    </ol>
-  </div>
+  <div class="container-narrow" ng-include="'views/get-started.html'"></div>
 </section>
 
 <section id="technology">
-  <div class="container-narrow">
-    <h3>Technology</h3>
-
-    <div class="row-fluid">
-      <div class="span2">
-        <h4 class="muted pull-right">Server</h4>
-      </div>
-      <div class="span10">
-        <div class="row-fluid">
-          <div class="span6">
-            <h4><a href="http://expressjs.com/">Express</a></h4>
-            <p>Powered by the de-facto node application framework with a sensible folder structure.</p>
-          </div>
-          <div class="span6">
-            <h4><a href="https://toolbelt.heroku.com/">Heroku</a> <small>Optional</small></h4>
-            <p>See your app live in minutes with a simple <code>git push</code>.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="row-fluid">
-      <div class="span2">
-        <h4 class="muted pull-right">Browser</h4>
-      </div>
-      <div class="span10">
-        <div class="row-fluid">
-          <div class="span6">
-            <h4><a href="http://html5boilerplate.com/">HTML5 Boilerplate</a></h4>
-            <p>
-              Lean, mobile-friendly HTML template with Google Analytics,
-              <a href="http://modernizr.com/" title="Modernizr">Modernizr</a>
-              and <a href="https://github.com/scottjehl/Respond" title="Respond.js">Respond.js</a>
-            </p>
-          </div>
-          <div class="span6">
-            <h4><a href="http://twitter.github.com/bootstrap/">Bootstrap</a> <small>Optional</small></h4>
-            <p>Use as much or as little as you'd like to kickstart your app's design.</p>
-          </div>
-        </div>
-        <div class="row-fluid">
-          <div class="span6">
-            <h4><a href="http://angularjs.org/">AngularJS</a></h4>
-            <p>Enhance HTML with data-binding, new functionality, and a service-oriented MVC architecture.</p>
-          </div>
-          <div class="span6">
-            <h4><a href="http://livereload.com/">LiveReload</a></h4>
-            <p>See your changes instantly upon save.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="row-fluid">
-      <div class="span2">
-        <h4 class="muted pull-right">Tooling</h4>
-      </div>
-      <div class="span5">
-        <h4><a href="http://gruntjs.com/">Grunt</a></h4>
-        <p>Serve, watch, reload, &amp; compile your app's resources by running <code>grunt server</code>.</p>
-      </div>
-      <div class="span5">
-        <h4><a href="http://twitter.github.com/bower/">Bower</a> <small>Optional</small></h4>
-        <p>Simplify management of browser dependencies.  Compiled &amp; minified.</p>
-      </div>
-    </div>
-
-  </div>
+  <div class="container-narrow" ng-include="'views/technology.html'"></div>
 </section>
 
 <footer>

--- a/src/client/views/home.html
+++ b/src/client/views/home.html
@@ -14,7 +14,7 @@
       </ul>
 
       <h3 class="muted">
-        {{ package.title }}
+        Genesis Skeleton
       </h3>
     </div>
 
@@ -29,7 +29,7 @@
     <h3>About</h3>
 
     <p>
-      {{ package.title }} aims to be the best starting point for your next
+      Genesis Skeleton aims to be the best starting point for your next
       <a href="http://expressjs.com/">Express</a> + <a href="http://angularjs.org/">AngularJS</a>
       app.
 
@@ -139,7 +139,7 @@
 <footer>
   <div class="container-narrow">
     <p>
-      &copy; {{ | date('Y') }} {{ package.title }}
+      &copy; 2013 Genesis Skeleton
     </p>
   </div>
 </footer>

--- a/src/client/views/technology.html
+++ b/src/client/views/technology.html
@@ -1,0 +1,65 @@
+<h3>Technology</h3>
+
+<div class="row-fluid">
+  <div class="span2">
+    <h4 class="muted pull-right">Server</h4>
+  </div>
+  <div class="span10">
+    <div class="row-fluid">
+      <div class="span6">
+        <h4><a href="http://expressjs.com/">Express</a></h4>
+        <p>Powered by the de-facto node application framework with a sensible folder structure.</p>
+      </div>
+      <div class="span6">
+        <h4><a href="https://toolbelt.heroku.com/">Heroku</a> <small>Optional</small></h4>
+        <p>See your app live in minutes with a simple <code>git push</code>.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row-fluid">
+  <div class="span2">
+    <h4 class="muted pull-right">Browser</h4>
+  </div>
+  <div class="span10">
+    <div class="row-fluid">
+      <div class="span6">
+        <h4><a href="http://html5boilerplate.com/">HTML5 Boilerplate</a></h4>
+        <p>
+          Lean, mobile-friendly HTML template with Google Analytics,
+          <a href="http://modernizr.com/" title="Modernizr">Modernizr</a>
+          and <a href="https://github.com/scottjehl/Respond" title="Respond.js">Respond.js</a>
+        </p>
+      </div>
+      <div class="span6">
+        <h4><a href="http://twitter.github.com/bootstrap/">Bootstrap</a> <small>Optional</small></h4>
+        <p>Use as much or as little as you'd like to kickstart your app's design.</p>
+      </div>
+    </div>
+    <div class="row-fluid">
+      <div class="span6">
+        <h4><a href="http://angularjs.org/">AngularJS</a></h4>
+        <p>Enhance HTML with data-binding, new functionality, and a service-oriented MVC architecture.</p>
+      </div>
+      <div class="span6">
+        <h4><a href="http://livereload.com/">LiveReload</a></h4>
+        <p>See your changes instantly upon save.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row-fluid">
+  <div class="span2">
+    <h4 class="muted pull-right">Tooling</h4>
+  </div>
+  <div class="span5">
+    <h4><a href="http://gruntjs.com/">Grunt</a></h4>
+    <p>Serve, watch, reload, &amp; compile your app's resources by running <code>grunt server</code>.</p>
+  </div>
+  <div class="span5">
+    <h4><a href="http://twitter.github.com/bower/">Bower</a> <small>Optional</small></h4>
+    <p>Simplify management of browser dependencies.  Compiled &amp; minified.</p>
+  </div>
+</div>

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -28,4 +28,3 @@ if ('development' === app.get('env')) {
 }
 
 app.get('/', routes.index);
-app.get('/views/*.html', routes.view);

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -6,7 +6,3 @@
 exports.index = function(req, res){
   res.render('index');
 };
-
-exports.view = function(req, res){
-  res.render(req.params[0]);
-};

--- a/src/server/views/layout.twig
+++ b/src/server/views/layout.twig
@@ -12,7 +12,7 @@
         <meta name="description"            content="{{ package.description }}">
         <meta name="author"                 content="{{ package.author.name }}">
 
-        <link rel="stylesheet" href="build/css/{{ package.name }}{% if ('production' == settings.env) %}.min{% endif %}.css?v={{ package.version }}">
+        <link rel="stylesheet" href="build/css/app{% if ('production' == settings.env) %}.min{% endif %}.css?v={{ package.version }}">
         <link href='http://fonts.googleapis.com/css?family=Wire+One' rel='stylesheet' type='text/css'>
     </head>
     <body>
@@ -26,11 +26,18 @@
             </div>
         </div>
 
-        <script src="build/js/{{ package.name }}{% if ('production' == settings.env) %}.min{% endif %}.js?v={{ package.version }}"></script>
+        <!-- Angular, CDN preferred -->
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.0.3/angular.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.0.3/angular-resource.min.js"></script>
+        <script>window.angular || document.write('<script src="build/js/lib/angular.min.js"><\/script>')</script>
+
+        <!-- App -->
+        <script src="build/js/app{% if ('production' == settings.env) %}.min{% endif %}.js?v={{ package.version }}"></script>
         <script>
             angular.bootstrap(document.body, ['app']);
         </script>
 
+        <!-- Google Analytics -->
         <script>
             var _gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview']];
             (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];


### PR DESCRIPTION
Success! (refs #5)

This PR makes several changes for this functionality to make sense:
- Addition of `grunt-angular-templates` (by @ericclemmons).
- Using `ngtemplates:app` to generate angular module `app.templates`.
- **REQUIRED** Adding `app.templates` as a dependency of `app`.  Didn't think this was necessary, but it is for the module to instantiate.
- Removed `routes.view`, which is no longer necessary
- Split apart libraries from the app in `min:*` and `concat:*`
- `min` targets pivot off of `concat` `dest` keys, except performing `.replace('.js', '.min.js')`, which is much more maintainable
- Removed dynamic `<link href="...">` and `<script src="...">` generation.  Instead, they rely on naming conventions like `app.js`, `app.css`, `all.js`, etc.
- Preferring GoogleCDN for Angular & ngResource.  Falls back to `build/js/lib/angular.js`.
- Removed the variables from `views/home.html` for now until we have a better demo.

@kwhitley I think this is in great shape!  I did _not_ change the module naming pattern, as the current angular "app" sucks, and I'd rather have a better demo.
