### PR TITLE
Replaces title injection

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -5,7 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
   <head>
     <meta charset="utf-8">
-    <title>{{ package.title }}</title>
+    <title ng-bind="package.title">Genesis Skeleton</title>
 
     <meta http-equiv="X-UA-Compatible"  content="IE=edge,chrome=1">
     <meta name="viewport"               content="width=device-width">


### PR DESCRIPTION
Replaces title injection with a safer (and invisible) `ng-bind="package.title"`, with `Genesis Skeleton` as the default page title.
