### PR TITLE
Replace grunt-reload with grunt-livereload

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -100,7 +100,7 @@ module.exports = function(grunt) {
         options : {
           cwd   : '<%= dirs.components %>'
         },
-        files   : { '<%= dirs.dist %>/img/': '<%= dirs.components %>/bootstrap/<%= files.img %>' }
+        files   : { '<%= dirs.dist %>/img/': '<%= dirs.components %>/bootstrap/img/<%= files.img %>' }
       },
       components: {
         options : {

--- a/grunt.js
+++ b/grunt.js
@@ -158,23 +158,22 @@ module.exports = function(grunt) {
       html      : '<%= dirs.dist %>/index.html'
     },
 
-    // Live-Reload Reverse-Proxy Server
+    // Server & tools
+    livereload  : {
+      options   : {
+        base    : '<%= dirs.dist %>'
+      },
+      files     : ['<%= dirs.dist %>/!(components)*'
+                  ,'<%= dirs.dist %>/!(components)/**.*']
+    },
     open:       {
       dev:      {
         url     : 'http://localhost:' + (process.env.PORT || 3000) + '/'
       }
     },
-    reload:     {
-      port      : process.env.PORT || 3000, // Browser-targeted port
-
-      proxy:    {
-        host    : 'localhost',
-        port    : 3001 // Source port
-      }
-    },
     server:     {
       script    : '<%= dirs.server %>/server.js',
-      port      : 3001 // Source Port
+      port      : process.env.PORT || 3000
     }
 
   });
@@ -184,13 +183,13 @@ module.exports = function(grunt) {
    */
 
   grunt.loadNpmTasks('grunt-angular-templates');
+  grunt.loadNpmTasks('grunt-css');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-less');
   grunt.loadNpmTasks('grunt-contrib-requirejs');
-  grunt.loadNpmTasks('grunt-css');
+  grunt.loadNpmTasks('grunt-livereload');
   grunt.loadNpmTasks('grunt-open');
-  grunt.loadNpmTasks('grunt-reload');
   grunt.loadNpmTasks('grunt-smushit');
   grunt.loadNpmTasks('grunt-usemin');
 
@@ -208,6 +207,6 @@ module.exports = function(grunt) {
   grunt.registerTask('compile', ['less', 'ngtemplates']);
   grunt.registerTask('build',   ['clean', 'default', 'minify']);
   grunt.registerTask('minify',  ['useminPrepare', 'concat', 'min', 'cssmin', 'requirejs', 'usemin', 'smushit']);
-  grunt.registerTask('server',  ['default', 'express-server', 'reload', 'watch']);
+  grunt.registerTask('server',  ['default', 'express-server', 'livereload', 'watch']);
 
 };

--- a/grunt.js
+++ b/grunt.js
@@ -17,9 +17,9 @@ module.exports = function(grunt) {
 
     files: {
       all       : '**/*',
-      img       : 'img/**/*',
+      img       : '**/*.{png,gif,jpg,jpeg}',
       js        : '**/*.js',
-      less      : 'less/**/*.less',
+      less      : '**/*.less',
       html      : '**/*.html'
     },
 
@@ -34,13 +34,27 @@ module.exports = function(grunt) {
     },
     clean:      ['<%= dirs.dist %>'],
     watch:      {
-      all:      {
+      lint:     {
         files   : ['grunt.js'
-                  ,'<%= dirs.public + files.all %>'
-                  ,'<%= dirs.server + files.all %>'
-                  ,'<%= dirs.client %>/app/<%= files.all %>'],
-        tasks   : ['lint', 'compile', 'concat:app', 'copy:public', 'copy:app', 'express-server', 'reload'],
-        options : { interrupt: true }
+                  ,'<%= dirs.client + files.js %>',
+                  ,'<%= dirs.server + files.js %>'],
+        tasks   : ['lint']
+      },
+      app:      {
+        files   : ['<%= dirs.client + files.js %>'],
+        tasks   : ['ngtemplates', 'concat']
+      },
+      server:   {
+        files   : ['<%= dirs.server + files.all %>'],
+        tasks   : ['express-server', 'livereload']
+      },
+      less:     {
+        files   : ['<%= dirs.client + files.less %>'],
+        tasks   : ['less']
+      },
+      public:   {
+        files   : ['<%= dirs.public + files.all %>'],
+        tasks   : ['copy:public']
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-less": "0.3.2",
     "grunt-contrib-clean": "0.3.0",
     "grunt-contrib-requirejs": "~0.3.4",
-    "grunt-livereload": "~0.1.0",
+    "grunt-livereload": "~0.1",
     "grunt-open": "0.1.0",
     "grunt-smushit": "0.3.8",
     "grunt-usemin": "~0.1.2"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "grunt-contrib-less": "0.3.2",
     "grunt-contrib-clean": "0.3.0",
     "grunt-contrib-requirejs": "~0.3.4",
+    "grunt-livereload": "~0.1.0",
     "grunt-open": "0.1.0",
-    "grunt-reload": "0.2.0",
     "grunt-smushit": "0.3.8",
     "grunt-usemin": "~0.1.2"
   }

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -17,9 +17,9 @@ app.use(express.bodyParser());
 app.use(express.methodOverride());
 app.use(express.cookieParser('change this value to something unique'));
 app.use(express.cookieSession());
+app.use(express.compress());
 app.use(api);
 app.use(express.static(path.join(__dirname, '../../dist')));
-app.use(express.compress());
 app.use(app.router);
 app.use(errors);
 


### PR DESCRIPTION
Refs #43 

I _hate_ having to build yet another thing myself, but we found that `grunt-reload` has significant issues with serving compressed content.  `grunt-reloadr` is better, except that it doesn't support CSS-only reloads.

So, now we have this one which supports CSS reloads & full-page reloads.

However, I'm **still** having issues with Express caching views/routes/etc.  It totally seems session based, but I can't find anything to prove it!
