### PR TITLE
Update README to point to website & restroe grunt server

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -175,11 +175,12 @@ module.exports = (grunt)->
   ###
   # Alias Tasks
   #
-  # - `grunt` for local development
-  # - `grunt build` for deployment
+  # - `grunt server` for local development
+  # - `grunt build` when deploying
   ###
 
-  grunt.registerTask('default',   [ 'clean', 'validate', 'prepare', 'express' ])
+  grunt.registerTask('default',   [ 'validate', 'prepare' ])
+  grunt.registerTask('server',    [ 'clean', 'default', 'express' ])
   grunt.registerTask('build',     [ 'clean', 'prepare', 'optimize' ])
   grunt.registerTask('validate',  [ 'jshint' ])
   grunt.registerTask('prepare',   [ 'less', 'ngtemplates', 'concat', 'copy' ])

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ Modern application skeleton:
 * [Bootstrap][6]
 * [Bower][8]
 
+**You can always find the latest instructions & guide at [http://genesis-skeleton.com/][0]**
+
 
 Requirements
 ------------
 
-    $ npm install -g grunt-cli
+    $ npm install -g grunt-cli bower
 
 
 Installation
@@ -37,8 +39,8 @@ Start an [Express][3] server with [LiveReload][5]:
 Customize
 ---------
 
-- `src/client/crossdomain.xml`
-- `src/client/humans.txt`
+- `src/public/crossdomain.xml`
+- `src/public/humans.txt`
 
 
 Deployment (with [Heroku][7])
@@ -65,6 +67,7 @@ License
 MIT
 
 
+[0]: http://genesis-skeleton.com/
 [1]: http://html5boilerplate.com/
 [2]: http://angularjs.org/
 [3]: http://expressjs.com/


### PR DESCRIPTION
@facultymatt I'm with you.  It was a mistake to remove `grunt server` and use `grunt [default]` instead.  This fixes that, restores `grunt server`, and now `grunt default` is basically just validation & preparing resources.  (For when you already have a server running, for instance).
