### PR TITLE
Update LiveReload & Fix Express Process

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -32,7 +32,7 @@ module.exports = (grunt)->
       dist:         '<%= dirs.dist %>'
 
 
-    watch:
+    regarde:
       app:
         files:      '<%= dirs.client + files.js %>'
         tasks:      [ 'jshint', 'concat', 'livereload' ]
@@ -165,10 +165,10 @@ module.exports = (grunt)->
   grunt.loadNpmTasks('grunt-contrib-copy')
   grunt.loadNpmTasks('grunt-contrib-jshint')
   grunt.loadNpmTasks('grunt-contrib-less')
+  grunt.loadNpmTasks('grunt-contrib-livereload')
   grunt.loadNpmTasks('grunt-contrib-mincss')
   grunt.loadNpmTasks('grunt-contrib-uglify')
-  grunt.loadNpmTasks('grunt-contrib-watch')
-  grunt.loadNpmTasks('grunt-livereload')
+  grunt.loadNpmTasks('grunt-regarde')
   grunt.loadNpmTasks('grunt-usemin')
 
 
@@ -184,5 +184,5 @@ module.exports = (grunt)->
   grunt.registerTask('build',     [ 'clean', 'prepare', 'optimize' ])
   grunt.registerTask('validate',  [ 'jshint' ])
   grunt.registerTask('prepare',   [ 'less', 'ngtemplates', 'concat', 'copy' ])
-  grunt.registerTask('express',   [ 'express-server', 'livereload', 'watch' ])
+  grunt.registerTask('express',   [ 'livereload-start', 'express-server', 'regarde' ])
   grunt.registerTask('optimize',  [ 'useminPrepare', 'concat', 'uglify', 'mincss', 'usemin' ])

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -35,11 +35,11 @@ module.exports = (grunt)->
     regarde:
       app:
         files:      '<%= dirs.client + files.js %>'
-        tasks:      [ 'jshint', 'concat', 'livereload' ]
+        tasks:      [ 'jshint', 'concat' ]
 
       partials:
         files:      '<%= dirs.client + files.html %>'
-        tasks:      [ 'copy:partials', 'ngtemplates', 'concat', 'livereload' ]
+        tasks:      [ 'copy:partials', 'ngtemplates', 'concat' ]
 
       server:
         files:      '<%= dirs.server + files.all %>'
@@ -52,6 +52,10 @@ module.exports = (grunt)->
       public:
         files:      '<%= dirs.public + files.all %>'
         tasks:      [ 'copy:public' ]
+
+      dist:
+        files:      '<%= dirs.dist + files.all %>'
+        tasks:      [ 'livereload' ]
 
 
     jshint:

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "grunt-contrib-copy": "0.4.0rc7",
     "grunt-contrib-jshint": "0.1.1rc6",
     "grunt-contrib-less": "0.5.0rc7",
+    "grunt-contrib-livereload": "~0.1.1",
     "grunt-contrib-mincss": "~0.4.0rc7",
     "grunt-contrib-uglify": "0.1.1rc6",
-    "grunt-contrib-watch": "~0.2.0rc7",
-    "grunt-livereload": "0.1.2",
+    "grunt-regarde": "~0.1.1",
     "grunt-usemin": "~0.1.4"
   }
 }


### PR DESCRIPTION
- Switched from my own `grunt-livereload` to `grunt-contrib-livereload`
- Switched from `grunt-contrib-watch` to `grunt-regarde`
- `express-server` now spans a new instance, so changes can be made and `livereload`ed

Refs #68
