### PR TITLE
fixed dependency on grunt-contrib-mincss

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-less": "~0.5.2",
-    "grunt-contrib-mincss": "~0.4.0rc7",
+    "grunt-contrib-mincss": "~0.4.0-rc7",
     "grunt-contrib-uglify": "~0.1.2",
     "grunt-contrib-watch": "~0.4.4",
     "grunt-express-server": "~0.3.1",


### PR DESCRIPTION
fixed dependency on grunt-contrib-mincss. the current dependency would error out for new installs.
