### PR TITLE
Upgrade grunt-contrib-watch to ~0.5

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -164,7 +164,7 @@ module.exports = (grunt)->
       options:
         debounceDelay:  200
         livereload:     true
-        nospawn:        true
+        spawn:          false
 
       # Any public-facing changes should reload the browser & re-run tests (which may depend on those resources)
       build:

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -158,7 +158,7 @@ module.exports = (grunt)->
       options:
         debounceDelay:  200
         livereload:     true
-        nospawn:        true
+        spawn:        	false
 
       # Any public-facing changes should reload the browser & re-run tests (which may depend on those resources)
       build:

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -19,7 +19,7 @@ module.exports = (grunt)->
   grunt.registerTask('build', [ 'clean', 'jshint', 'copy', 'ngtemplates', 'less' ])
 
   # Optimize pre-built, web-accessible resources for production, primarily `usemin`
-  grunt.registerTask('optimize', [ 'useminPrepare', 'concat', 'uglify', 'mincss', 'usemin' ])
+  grunt.registerTask('optimize', [ 'useminPrepare', 'concat', 'ngmin:all', 'uglify', 'mincss', 'usemin' ])
 
 
   # Configuration
@@ -136,6 +136,12 @@ module.exports = (grunt)->
         src:        '<%= CSS_FILES %>'
         dest:       '<%= BUILD_DIR %>'
         ext:        '.min.css'
+        
+    # Add ngmin to the build process. 
+    ngmin:
+      all:
+        src:['<%= BUILD_DIR %>/app/scripts/all.min.js']
+        dest: '<%= BUILD_DIR %>/app/scripts/all.min.js'
 
     # Convert Angular `.html` templates to `.js` in the `app` module
     ngtemplates:
@@ -203,3 +209,4 @@ module.exports = (grunt)->
   grunt.loadNpmTasks('grunt-express-server')
   grunt.loadNpmTasks('grunt-karma')
   grunt.loadNpmTasks('grunt-usemin')
+  grunt.loadNpmTasks('grunt-ngmin')

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -19,7 +19,7 @@ module.exports = (grunt)->
   grunt.registerTask('build', [ 'clean', 'jshint', 'copy', 'ngtemplates', 'less' ])
 
   # Optimize pre-built, web-accessible resources for production, primarily `usemin`
-  grunt.registerTask('optimize', [ 'useminPrepare', 'concat', 'ngmin:all', 'uglify', 'mincss', 'usemin' ])
+  grunt.registerTask('optimize', [ 'useminPrepare', 'concat', 'uglify', 'mincss', 'usemin' ])
 
 
   # Configuration
@@ -136,12 +136,6 @@ module.exports = (grunt)->
         src:        '<%= CSS_FILES %>'
         dest:       '<%= BUILD_DIR %>'
         ext:        '.min.css'
-        
-    # Add ngmin to the build process. 
-    ngmin:
-      all:
-        src:['<%= BUILD_DIR %>/app/scripts/all.min.js']
-        dest: '<%= BUILD_DIR %>/app/scripts/all.min.js'
 
     # Convert Angular `.html` templates to `.js` in the `app` module
     ngtemplates:
@@ -164,7 +158,7 @@ module.exports = (grunt)->
       options:
         debounceDelay:  200
         livereload:     true
-        spawn:          false
+        nospawn:        true
 
       # Any public-facing changes should reload the browser & re-run tests (which may depend on those resources)
       build:
@@ -209,4 +203,3 @@ module.exports = (grunt)->
   grunt.loadNpmTasks('grunt-express-server')
   grunt.loadNpmTasks('grunt-karma')
   grunt.loadNpmTasks('grunt-usemin')
-  grunt.loadNpmTasks('grunt-ngmin')

--- a/package.json
+++ b/package.json
@@ -42,10 +42,9 @@
     "grunt-contrib-less": "~0.5.2",
     "grunt-contrib-mincss": "~0.4.0-rc7",
     "grunt-contrib-uglify": "~0.1.2",
-    "grunt-contrib-watch": "~0.5.1",
+    "grunt-contrib-watch": "~0.4.4",
     "grunt-express-server": "~0.3.1",
-    "grunt-usemin": "~0.1.12",
-    "grunt-ngmin": "0.0.3"
+    "grunt-usemin": "~0.1.12"
   },
   "devDependencies": {
     "grunt-karma": "~0.4.5"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-contrib-less": "~0.5.2",
     "grunt-contrib-mincss": "~0.4.0-rc7",
     "grunt-contrib-uglify": "~0.1.2",
-    "grunt-contrib-watch": "~0.4.4",
+    "grunt-contrib-watch": "~0.5.1",
     "grunt-express-server": "~0.3.1",
     "grunt-usemin": "~0.1.12"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "grunt-contrib-uglify": "~0.1.2",
     "grunt-contrib-watch": "~0.4.4",
     "grunt-express-server": "~0.3.1",
-    "grunt-usemin": "~0.1.12"
+    "grunt-usemin": "~0.1.12",
+    "grunt-ngmin": "0.0.3"
   },
   "devDependencies": {
     "grunt-karma": "~0.4.5"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-contrib-less": "~0.5.2",
     "grunt-contrib-mincss": "~0.4.0-rc7",
     "grunt-contrib-uglify": "~0.1.2",
-    "grunt-contrib-watch": "~0.4.4",
+    "grunt-contrib-watch": "~0.5.1",
     "grunt-express-server": "~0.3.1",
     "grunt-usemin": "~0.1.12",
     "grunt-ngmin": "0.0.3"


### PR DESCRIPTION
I (and apparently other ppl) experienced some issues with grunt-contrib-watch and grunt 0.4 (basically the livereload is not happening anymore after a certain time); this 0.5 grunt-watch version seems to be way better. I also updated the nospawn to "spawn" in the Gruntfile since the spec changed (even if nospawn still works)

It's really only one commit but had to reset the other ones I made for the ngmin PR so they're not related
